### PR TITLE
Add in database code for a single pointing

### DIFF
--- a/gotoalert/__init__.py
+++ b/gotoalert/__init__.py
@@ -1,1 +1,3 @@
-from . import alert, comms, csv2htmltable, definitions, output
+"""GOTO-alert handles incoming VOEvents for the GOTO telescope."""
+
+from . import alert, comms, csv2htmltable, definitions, output  # noqa: F401

--- a/gotoalert/alert.py
+++ b/gotoalert/alert.py
@@ -2,13 +2,12 @@
 """Event handlers for VOEvents."""
 
 import logging
-import os
 
 import astropy.units as u
 
 from .comms import send_email, send_slackmessage
 from .definitions import get_event_data, get_obs_data, goto_north, goto_south
-from .output import create_webpages, write_csv
+from .output import create_webpages
 
 PATH = "./www"
 

--- a/gotoalert/alert.py
+++ b/gotoalert/alert.py
@@ -7,6 +7,7 @@ import astropy.units as u
 from astropy.time import Time
 
 from .comms import send_email, send_slackmessage
+from .database import db_insert
 from .definitions import get_event_data, get_obs_data, goto_north, goto_south
 from .output import create_webpages
 
@@ -76,6 +77,11 @@ def event_handler(payload, log=None, write_html=True, send_messages=False):
     except Exception as err:
         log.warning(err)
         return
+
+    # It's an interesting event!
+
+    # Add the event into the GOTO observation DB
+    db_insert(event_data, log)
 
     # Get observing data for the event at each site
     target = event_data['event_target']

--- a/gotoalert/alert.py
+++ b/gotoalert/alert.py
@@ -23,7 +23,7 @@ def check_event_type(event_data, log):
     # Get alert name
     if event_data['type'] is None:
         raise ValueError('Ignoring unrecognised event type: {}'.format(event_data['ivorn']))
-    log.info('Recognised event type: {} ({})'.format(event_data['name'], event_data['type']))
+    log.info('Recognised event type: {} ({})'.format(event_data['base_name'], event_data['type']))
 
 
 def check_event_position(event_data, log):
@@ -101,15 +101,13 @@ def event_handler(payload, log=None, write_html=True, send_messages=False):
 
         # Send messages
         if send_messages:
-            event_name = event_data['name']
-            trigger_id = event_data['trigger_id']
-            file_name = event_name + trigger_id
+            file_name = event_data['event_name']
             file_path = PATH + "{}_transients/".format(site_name)
 
             # Send email
             email_subject = "Detection from {}".format(site_name)
             email_link = 'http://118.138.235.166/~obrads'
-            email_body = "{} Detection: See more at {}".format(event_name, email_link)
+            email_body = "{} Detection: See more at {}".format(event_data['type'], email_link)
 
             send_email(fromaddr="lapalmaobservatory@gmail.com",
                        toaddr="aobr10@student.monash.edu",
@@ -122,11 +120,11 @@ def event_handler(payload, log=None, write_html=True, send_messages=False):
 
             # Send message to Slack
             if site_name == "goto_north":
-                send_slackmessage(event_name,
+                send_slackmessage(event_data['event_name'],
                                   str(event_data["event_time"])[:22],
                                   str(event_data["event_coord"].ra.deg),
                                   str(event_data["event_coord"].dec.deg),
                                   file_name)
                 log.debug('Sent slack message for {}'.format(site_name))
 
-    log.info('Event {}{} processed'.format(event_data['name'], event_data['trigger_id']))
+    log.info('Event {} processed'.format(event_data['event_name']))

--- a/gotoalert/alert.py
+++ b/gotoalert/alert.py
@@ -61,7 +61,10 @@ def check_obs_params(site_data, log):
 
 
 def event_handler(payload, log=None, write_html=True, send_messages=False):
-    """Handle a VOEvent payload."""
+    """Handle a VOEvent payload.
+
+    Returns the event data dict if the event is interesting, or None if it's been rejected.
+    """
     # Create a logger if one isn't given
     if log is None:
         logging.basicConfig(level=logging.DEBUG)
@@ -76,7 +79,7 @@ def event_handler(payload, log=None, write_html=True, send_messages=False):
         check_event_position(event_data, log)
     except Exception as err:
         log.warning(err)
-        return
+        return None
 
     # It's an interesting event!
 
@@ -134,3 +137,4 @@ def event_handler(payload, log=None, write_html=True, send_messages=False):
                 log.debug('Sent slack message for {}'.format(site_name))
 
     log.info('Event {} processed'.format(event_data['event_name']))
+    return event_data

--- a/gotoalert/alert.py
+++ b/gotoalert/alert.py
@@ -58,7 +58,7 @@ def check_obs_params(obs_data, log):
     log.info('Target is up for longer than 1:30 tonight at {}'.format(name))
 
 
-def event_handler(v, log=None, write_html=True, send_messages=False):
+def event_handler(payload, log=None, write_html=True, send_messages=False):
     """Handle a VOEvent payload."""
     # Create a logger if one isn't given
     if log is None:
@@ -66,7 +66,7 @@ def event_handler(v, log=None, write_html=True, send_messages=False):
         log = logging.getLogger('goto-alert')
 
     # Get event data from the payload
-    event_data = get_event_data(v)
+    event_data = get_event_data(payload)
 
     # Check if it's an event we want to process
     try:

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -1,0 +1,106 @@
+#! /opt/local/bin/python3.6
+"""Functions to add events into the GOTO Observation Database."""
+
+import obsdb as db
+
+DEFAULT_USER = 'goto'
+
+DEFAULT_MPOINTING = {'userKey': None,
+                     'objectName': None,
+                     'ra': None,
+                     'decl': None,
+                     # auto filled values
+                     'minTime': None,
+                     # put in at rank 6, marked as ToO
+                     'ToO': True,
+                     'start_rank': 6,
+                     # default to 3 pointings, at least hour apart, valid for a day
+                     'num_todo': 3,
+                     'valid_time': 24 * 60,
+                     'wait_time': 60,
+                     # default values
+                     'maxSunAlt': -15,
+                     'maxMoon': 'B',
+                     'minMoonSep': 30,
+                     'minAlt': 40,
+                     }
+
+DEFAULT_EXPSET = {'numexp': 5,
+                  'expTime': 120,
+                  'filt': 'L',
+                  'binning': 1,
+                  'typeFlag': 'SCIENCE',
+                  }
+
+
+def db_insert(event_data, log):
+    """Insert an event into the ObsDB.
+
+    In the future this will need to work out which tiles the event covers, using GOTO-tile to
+    parse skymaps and so on. Even for a single pointing it should be inserted on-grid.
+    It should also alter the parameters depending on the event, most obviously the rank but also
+    different filter sets, times between visits and so on.
+
+    But for now just add a single pointing at the event centre, with pre-set parameters.
+    """
+    log.info('Inserting event {} into GOTO database'.format(event_data['event_name']))
+
+    # Add a single pointing
+    try:
+        add_single_pointing(event_data, log)
+        log.info('Database insersion complete')
+    except Exception as err:
+        log.error(err)
+        log.warning('Unable to insert event into database')
+
+
+def add_single_pointing(event_data, log):
+    """Simply add a single pointing at the coordinates given in the alert."""
+    with db.open_session() as session:
+        username = DEFAULT_USER
+        userkey = db.get_userkey(session, username)
+
+        # Create Event and add it to the database
+        event = db.Event(ivo=event_data['ivorn'],
+                         name=event_data['event_name'],
+                         source=event_data['source'],
+                         )
+        try:
+            session.add(event)
+            session.commit()
+        except Exception as err:
+            session.rollback()
+            raise
+
+        # Get default Mpointing infomation and add event name and coords
+        mp_data = DEFAULT_MPOINTING.copy()
+        mp_data['userKey'] = userkey
+        mp_data['objectName'] = event_data['event_name']
+        coord = event_data['event_coord']
+        mp_data['ra'] = coord.ra.value
+        mp_data['decl'] = coord.dec.value
+
+        # Create Mpointing
+        mpointing = db.Mpointing(**mp_data)
+        mpointing.event = event
+
+        # Get default Exposure Set infomation
+        expsets_data = [DEFAULT_EXPSET.copy()]
+
+        # Create Exposure Sets
+        for expset_data in expsets_data:
+            exposure_set = db.ExposureSet(**expset_data)
+            mpointing.exposure_sets.append(exposure_set)
+
+        # Update mintime
+        total_exptime = sum([(es['expTime'] + 30) * es['numexp'] for es in expsets_data])
+        mpointing.minTime = total_exptime
+
+        # Add Mpointing to the database
+        try:
+            session.add(mpointing)
+            session.commit()
+            log.debug(mpointing)
+        except Exception as err:
+            session.rollback()
+            raise

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -4,6 +4,8 @@
 import obsdb as db
 
 DEFAULT_USER = 'goto'
+DEFAULT_PW = 'gotoobs'
+DEFAULT_NAME = 'GOTO automated alerts'
 
 DEFAULT_MPOINTING = {'userKey': None,
                      'objectName': None,
@@ -57,8 +59,11 @@ def db_insert(event_data, log):
 def add_single_pointing(event_data, log):
     """Simply add a single pointing at the coordinates given in the alert."""
     with db.open_session() as session:
-        username = DEFAULT_USER
-        userkey = db.get_userkey(session, username)
+        try:
+            userkey = db.get_userkey(session, DEFAULT_USER)
+        except Exception:
+            db.add_user(session, DEFAULT_USER, DEFAULT_PW, DEFAULT_NAME)
+            userkey = db.get_userkey(session, DEFAULT_USER)
 
         # Create Event and add it to the database
         event = db.Event(ivo=event_data['ivorn'],

--- a/gotoalert/definitions.py
+++ b/gotoalert/definitions.py
@@ -36,13 +36,13 @@ def goto_south():
 
 ALERT_DICTIONARY = {'XRT_Pos': {'type': 'GRB',
                                 'source': 'SWIFT',
-                                'name': 'Swift_XRT_POS'},
+                                'base_name': 'Swift_XRT_POS'},
                     'BAT_GRB_Pos': {'type': 'GRB',
                                     'source': 'SWIFT',
-                                    'name': 'Swift_BAT_GRB_POS'},
+                                    'base_name': 'Swift_BAT_GRB_POS'},
                     'GBM_Gnd_Pos': {'type': 'GRB',
                                     'source': 'Fermi',
-                                    'name': 'Fermi_GMB_GND_POS'},
+                                    'base_name': 'Fermi_GMB_GND_POS'},
                     }
 
 
@@ -80,6 +80,7 @@ def get_event_data(payload):
         data['trigger_id'] = top_params['TrigID']['value']
     else:
         data['trigger_id'] = 0
+    data['event_name'] = data['base_name'] + '_' + data['trigger_id']
 
     # Get contact email, if there is one
     try:

--- a/gotoalert/output.py
+++ b/gotoalert/output.py
@@ -18,7 +18,7 @@ import pandas as pd
 from .csv2htmltable import write_table
 
 
-def write_csv(filename, event_data, all_obs_data):
+def write_csv(filename, event_data, obs_data):
     """Write the CSV file."""
     data = OrderedDict()
     data['trigger'] = event_data['name'] + event_data['trigger_id']
@@ -28,9 +28,9 @@ def write_csv(filename, event_data, all_obs_data):
     data['Galactic Distance'] = event_data["dist_galactic_center"]
     data['Galactic Lat'] = event_data["object_galactic_lat"]
 
-    for telescope in all_obs_data:
-        obs_data = all_obs_data[telescope]
-        data[telescope] = obs_data['alt_observable']
+    for site_name in obs_data:
+        site_data = obs_data[site_name]
+        data[site_name] = site_data['alt_observable']
 
     fieldnames = list(data.keys())
 
@@ -46,18 +46,18 @@ def write_csv(filename, event_data, all_obs_data):
             writer.writerow(data)
 
 
-def create_graphs(file_path, event_data, obs_data, fov=30):
+def create_graphs(file_path, event_data, site_data, fov=30):
     """Create airmass and finder plots."""
     # Get data
     name = event_data['name']
     trigger_id = event_data['trigger_id']
     coord = event_data['event_coord']
     target = event_data['event_target']
-    observer = obs_data['observer']
+    observer = site_data['observer']
 
     # Plot airmass during the night
-    delta_t = obs_data['sun_rise'] - obs_data['sun_set']
-    time_range = obs_data['sun_set'] + delta_t * np.linspace(0, 1, 75)
+    delta_t = site_data['sun_rise'] - site_data['sun_set']
+    time_range = site_data['sun_set'] + delta_t * np.linspace(0, 1, 75)
     plot_airmass(coord, observer, time_range, altitude_yaxis=True, style_sheet=dark_style_sheet)
     airmass_file = "{}{}_AIRMASS.png".format(name, trigger_id)
     plt.savefig(os.path.join(file_path, 'airmass_plots', airmass_file))
@@ -73,18 +73,18 @@ def create_graphs(file_path, event_data, obs_data, fov=30):
     plt.clf()
 
 
-def write_html(file_path, event_data, obs_data):
+def write_html(file_path, event_data, site_data):
     """Write the HTML page."""
     name = event_data['name']
     trigger_id = event_data['trigger_id']
     event_type = event_data['type']
 
-    telescope = obs_data['observer']
+    site_name = site_data['observer'].name
 
     html_file = '{}{}.html'.format(name, trigger_id)
     with open(file_path + html_file, 'w') as f:
 
-        title = "New transient for {} from {}".format(telescope.name, name)
+        title = "New transient for {} from {}".format(site_name, name)
         f.write('<!DOCTYPE html><html lang="en"><head>{}</head><body>'.format(title))
         f.write('<p>https://gcn.gsfc.nasa.gov/other/{}.{}</p>'.format(trigger_id, event_type))
         f.write('<p>Event ID:  {}</p>'.format(trigger_id))
@@ -108,12 +108,12 @@ def write_html(file_path, event_data, obs_data):
         f.write('<p>Observation Details: Time in UTC</p>')
 
         # Write obs times
-        target_rise = obs_data["target_rise"].iso
-        target_set = obs_data["target_set"].iso
-        sun_set = obs_data["sun_set"].iso
-        sun_rise = obs_data["sun_rise"].iso
-        observation_start = obs_data["observation_start"].iso
-        observation_end = obs_data["observation_end"].iso
+        target_rise = site_data["target_rise"].iso
+        target_set = site_data["target_set"].iso
+        sun_set = site_data["sun_set"].iso
+        sun_rise = site_data["sun_rise"].iso
+        observation_start = site_data["observation_start"].iso
+        observation_end = site_data["observation_end"].iso
         f.write('<p>Target Rise: {}</p>'.format(target_rise))
         f.write('<p>Target Set:  {}</p>'.format(target_set))
         f.write('<p>Start of night:  {}</p>'.format(sun_set))
@@ -124,7 +124,7 @@ def write_html(file_path, event_data, obs_data):
         # Write obs checks
         galactic_dist = event_data["dist_galactic_center"]
         galactic_lat = event_data["object_galactic_lat"]
-        moon = not obs_data["moon_observable"]
+        moon = not site_data["moon_observable"]
 
         f.write('<p>Galactic Distance:   {:.3f} degrees</p>'.format(galactic_dist))
         f.write('<p>Galactic Lat:    {:.3f} degrees</p>'.format(galactic_lat))
@@ -150,26 +150,26 @@ def write_topten(csv_path, topten_path):
         f.write('<p>{}</p>'.format(html_table))
 
 
-def create_webpages(event_data, all_obs_data, telescope, web_path):
+def create_webpages(event_data, obs_data, site_name, web_path):
     """Create the output webpages for the given telescope."""
-    obs_data = all_obs_data[telescope.name]
+    site_data = obs_data[site_name]
 
     # write master csv file
-    write_csv(os.path.join(web_path, 'master.csv'), event_data, all_obs_data)
+    write_csv(os.path.join(web_path, 'master.csv'), event_data, obs_data)
 
     # Find file paths
-    web_directory = '{}_transients'.format(telescope.name)
+    web_directory = '{}_transients'.format(site_name)
     file_path = os.path.join(web_path, web_directory)
 
     # Create graphs
-    create_graphs(file_path, event_data, obs_data)
+    create_graphs(file_path, event_data, site_data)
 
     # Write HTML
-    write_html(file_path, event_data, obs_data)
+    write_html(file_path, event_data, site_data)
 
     # Write CSV
-    csv_file = telescope.name + ".csv"
-    write_csv(os.path.join(file_path, csv_file), event_data, all_obs_data)
+    csv_file = site_name + ".csv"
+    write_csv(os.path.join(file_path, csv_file), event_data, obs_data)
 
     # Write latest 10 page
     topten_file = "recent_ten.html"

--- a/gotoalert/output.py
+++ b/gotoalert/output.py
@@ -21,7 +21,7 @@ from .csv2htmltable import write_table
 def write_csv(filename, event_data, obs_data):
     """Write the CSV file."""
     data = OrderedDict()
-    data['trigger'] = event_data['name'] + event_data['trigger_id']
+    data['trigger'] = event_data['event_name']
     data['date'] = event_data["event_time"]
     data['ra'] = event_data["event_coord"].ra.deg
     data['dec'] = event_data["event_coord"].dec.deg
@@ -49,8 +49,7 @@ def write_csv(filename, event_data, obs_data):
 def create_graphs(file_path, event_data, site_data, fov=30):
     """Create airmass and finder plots."""
     # Get data
-    name = event_data['name']
-    trigger_id = event_data['trigger_id']
+    event_name = event_data['event_name']
     coord = event_data['event_coord']
     target = event_data['event_target']
     observer = site_data['observer']
@@ -59,7 +58,7 @@ def create_graphs(file_path, event_data, site_data, fov=30):
     delta_t = site_data['sun_rise'] - site_data['sun_set']
     time_range = site_data['sun_set'] + delta_t * np.linspace(0, 1, 75)
     plot_airmass(coord, observer, time_range, altitude_yaxis=True, style_sheet=dark_style_sheet)
-    airmass_file = "{}{}_AIRMASS.png".format(name, trigger_id)
+    airmass_file = "{}_AIRMASS.png".format(event_name)
     plt.savefig(os.path.join(file_path, 'airmass_plots', airmass_file))
     plt.clf()
 
@@ -68,25 +67,26 @@ def create_graphs(file_path, event_data, site_data, fov=30):
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
         plot_finder_image(target, fov_radius=fov * u.arcmin, grid=False, reticle=True)
-    airmass_file = "{}{}_FINDER.png".format(name, trigger_id)
+    airmass_file = "{}_FINDER.png".format(event_name)
     plt.savefig(os.path.join(file_path, 'finder_charts', airmass_file))
     plt.clf()
 
 
 def write_html(file_path, event_data, site_data):
     """Write the HTML page."""
-    name = event_data['name']
+    event_name = event_data['event_name']
     trigger_id = event_data['trigger_id']
-    event_type = event_data['type']
+    source = event_data['source']
 
     site_name = site_data['observer'].name
 
-    html_file = '{}{}.html'.format(name, trigger_id)
-    with open(file_path + html_file, 'w') as f:
+    html_file = '{}.html'.format(event_name)
+    html_path = os.path.join(file_path, html_file)
+    with open(html_path, 'w') as f:
 
-        title = "New transient for {} from {}".format(site_name, name)
+        title = "New transient for {} from {}".format(site_name, event_data['base_name'])
         f.write('<!DOCTYPE html><html lang="en"><head>{}</head><body>'.format(title))
-        f.write('<p>https://gcn.gsfc.nasa.gov/other/{}.{}</p>'.format(trigger_id, event_type))
+        f.write('<p>https://gcn.gsfc.nasa.gov/other/{}.{}</p>'.format(trigger_id, source.lower()))
         f.write('<p>Event ID:  {}</p>'.format(trigger_id))
 
         # Write event time
@@ -131,8 +131,8 @@ def write_html(file_path, event_data, site_data):
         f.write('<p>Target within 5 degrees of the moon? {}</p>'.format(moon))
 
         # Write links to plots
-        f.write('<img src=finder_charts/{}{}_FINDER.png>'.format(name, trigger_id))
-        f.write('<img src=airmass_plots/{}{}_AIRMASS.png>'.format(name, trigger_id))
+        f.write('<img src=finder_charts/{}_FINDER.png>'.format(event_name))
+        f.write('<img src=airmass_plots/{}_AIRMASS.png>'.format(event_name))
         f.write('</body></html>')
 
 

--- a/scripts/gotoalert
+++ b/scripts/gotoalert
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
+"""A script to handle any events passed to STDIN."""
 
-import os
 import sys
-import pkg_resources
-import voeventparse as vp
 
 from gotoalert.alert import event_handler
 
 
 if __name__ == '__main__':
-    v = vp.loads(sys.stdin.buffer.read())
-    event_handler(v)
+    payload = sys.stdin.buffer.read()
+    event_handler(payload)

--- a/scripts/test_gotoalert
+++ b/scripts/test_gotoalert
@@ -13,4 +13,5 @@ if __name__ == '__main__':
     data_dir = pkg_resources.resource_filename('gotoalert', 'data')
     testdata_path = os.path.join(data_dir, 'ivo__nasa.gsfc.gcn_SWIFTBAT_GRB_Pos_813449030')
     with open(testdata_path, "rb") as f:
-        event_handler(f)
+        payload = f.read()
+        event_handler(payload)

--- a/scripts/test_gotoalert
+++ b/scripts/test_gotoalert
@@ -7,14 +7,10 @@ from gotoalert.alert import event_handler
 
 import pkg_resources
 
-import voeventparse as vp
-
 
 if __name__ == '__main__':
     # used for local testing
     data_dir = pkg_resources.resource_filename('gotoalert', 'data')
     testdata_path = os.path.join(data_dir, 'ivo__nasa.gsfc.gcn_SWIFTBAT_GRB_Pos_813449030')
     with open(testdata_path, "rb") as f:
-        v = vp.load(f)
-
-    event_handler(v)
+        event_handler(f)


### PR DESCRIPTION
This branch is the first implementation of adding events directly into the GOTO Observation Database (see https://github.com/GOTO-OBS/goto-obsdb).

Start off simply, whenever an event comes in we add a single pointing directly targeting the event coordinates. It adds a single exposure set of 5 120s L images, and it's due to be repeated three times at least an hour apart over the night. Of course all of those parameters can be changed but this is a reasonable place to start.

I also move a few things around, but 13772f6 is the key commit - see the addition of https://github.com/GOTO-OBS/goto-alert/compare/grb_singlep?expand=1#diff-481e2e4a067bcba327f466308d6176e4.

There's still a known delay before the caretaker updates the database, see GOTO-OBS/goto-obsdb#5. Ideally we'd caretaker after insertion like we used to, which should be easy but will need an ObsDB update.

Of course this will need something to run it where it can access the database, which is what the sentinel is for - see GOTO-OBS/g-tecs#346.