### PR TITLE
Quick fix of two bugs

### DIFF
--- a/gotoalert/events.py
+++ b/gotoalert/events.py
@@ -38,7 +38,14 @@ class Event(object):
         self.role = self.voevent.attrib['role']
 
         # Get event time
-        self.time = Time(vp.convenience.get_event_time_as_utc(self.voevent, index=0))
+        event_time = vp.convenience.get_event_time_as_utc(self.voevent, index=0)
+        if event_time is None:
+            # Sometimes we might get system test events from the server.
+            # They (annoyingly) don't actually have an event attached, even a fake one,
+            # so don't have a time. Just return here, the handler will ignore it.
+            self.time = None
+            return
+        self.time = Time(event_time)
 
         # Get event position (RA/DEC)
         position = vp.get_event_position(self.voevent)

--- a/gotoalert/events.py
+++ b/gotoalert/events.py
@@ -75,11 +75,11 @@ class Event(object):
 
         # Get the trigger ID, if there is one
         top_params = vp.get_toplevel_params(self.voevent)
-        if 'TrigID' in top_params:
-            self.trigger_id = top_params['TrigID']['value']
-        else:
+        try:
+            self.trigger_id = int(top_params['TrigID']['value'])
+        except Exception:
             self.trigger_id = 0
-        self.name = self.base_name + '_' + self.trigger_id
+        self.name = '{}_{:.0f}'.format(self.base_name, self.trigger_id)
 
         # Get contact email, if there is one
         try:


### PR DESCRIPTION
* The previous code replaced the trigger ID with an integer is one wasn't given, but then still assumed it was a string (3cb5cdb).
* Comet produces these test events (see below) which don't have any event info and broke the previous code. So now if we get an event without an actual event attached (no event time) then we just return immediately.

```
<?xml version=\'1.0\' encoding=\'UTF-8\'?>
<voe:VOEvent xmlns:voe="http://www.ivoa.net/xml/VOEvent/v2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ivorn="ivo://voevent.4pisky.org/voevent-receive#TestEvent-2018-10-26T13:58:39Z" role="test" version="2.0" xsi:schemaLocation="http://www.ivoa.net/xml/VOEvent/v2.0 http://www.ivoa.net/xml/VOEvent/VOEvent-v2.0.xsd">
  <Who>
    <AuthorIVORN>ivo://voevent.4pisky.org/voevent-receive</AuthorIVORN>
    <Date>2018-10-26T13:58:39Z</Date>
  </Who>
  <What>
    <Description>Broker test event generated by Comet 3.0.0.</Description>
    <Reference uri="http://comet.transientskp.org/"/>
  </What>
</voe:VOEvent>
```