### PR TITLE
Alter Mpointing observation strategy

### DIFF
--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -252,7 +252,7 @@ def add_tiles(event, log):
 
         # Limit the number of tiles added
         if event.type == 'GW':
-            masked_table = masked_table[:50]
+            masked_table = masked_table[:200]
         elif params.MAX_TILES:
             masked_table = masked_table[:params.MAX_TILES]
 

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -96,16 +96,10 @@ def get_mpointing_info(event):
     mp_data['ra'] = None
     mp_data['dec'] = None
 
-    # The Mpointing shoudl be valid immediately after the event time
+    # The Mpointing should be valid immediately after the event time
+    # The stop time depends is defined in params
     mp_data['start_time'] = event.time
-
-    # The stop time depends on the type of event:
-    #  - If it's a GW event then there's no stop time set
-    #  - Otherwise it will stop after X days, defined in params
-    if event.type == 'GW':
-        mp_data['stop_time'] = None
-    else:
-        mp_data['stop_time'] = event.time + params.VALID_DAYS * u.day
+    mp_data['stop_time'] = event.time + params.VALID_DAYS * u.day
 
     # All Events should be Targets of Opportunity, that's the point!
     mp_data['too'] = True
@@ -118,18 +112,17 @@ def get_mpointing_info(event):
     else:
         mp_data['start_rank'] = 106
 
-    # Candence also depends on type (note times in minutes!):
-    #  - If it's a GW event then do as many as possible, valid forever and immediately
-    #    re-enter into the queue when done
-    #  - Otherwise do three, a day apart
+    # Candence also depends on type (note times are in minutes!):
+    #  - If it's a GW event then do as many as possible before the stop time, one every 3 hours
+    #  - Otherwise do three, with 4 hours after the first then a day between the others
     if event.type == 'GW':
         mp_data['num_todo'] = 99
-        mp_data['wait_time'] = -1
-        mp_data['valid_time'] = -1
+        mp_data['wait_time'] = 3 * 60
     else:
         mp_data['num_todo'] = 3
-        mp_data['wait_time'] = 60
-        mp_data['valid_time'] = 60 * 24
+        mp_data['wait_time'] = [4 * 60, 12 * 60, 12 * 60]
+    # Valid time is not an issue, stay valid while in the queue
+    mp_data['valid_time'] = -1
 
     # The minimum pointing time is based on the ExposureSet
     # +30s for readout, probably generous

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -242,7 +242,7 @@ def add_tiles(event, log):
         # Mask the table based on tile probs
         log.debug('Masking tile table')
         if event.type == 'GW':
-            mask = table['prob'] > 0.01
+            mask = table['prob'] > 0.001
         elif params.MIN_TILE_PROB:
             mask = table['prob'] > params.MIN_TILE_PROB
         else:

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -119,7 +119,7 @@ def get_mpointing_info(event):
     #  - Otherwise do three, with 4 hours after the first then a day between the others
     if event.type == 'GW':
         mp_data['num_todo'] = 99
-        mp_data['wait_time'] = 3 * 60
+        mp_data['wait_time'] = 0
     else:
         mp_data['num_todo'] = 3
         mp_data['wait_time'] = [4 * 60, 12 * 60, 12 * 60]

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -242,7 +242,11 @@ def add_tiles(event, log):
         # Mask the table based on tile probs
         log.debug('Masking tile table')
         if event.type == 'GW':
-            mask = table['prob'] > 0.001
+            # as an initial best fit, take the fraction based on the 50% confidence area
+            # see https://github.com/GOTO-OBS/goto-alert/issues/26
+            frac = len(skymap._pixels_within_contour(0.5)) / skymap.npix
+            x = 0.00003
+            mask = table['prob'] > x / frac
         elif params.MIN_TILE_PROB:
             mask = table['prob'] > params.MIN_TILE_PROB
         else:

--- a/gotoalert/events.py
+++ b/gotoalert/events.py
@@ -172,7 +172,8 @@ class Event(object):
             os.mkdir(path)
 
         filename = quote_plus(self.ivorn)
-        with open(path + filename, 'wb') as f:
+        savepath = os.path.join(path, filename)
+        with open(savepath, 'wb') as f:
             f.write(self.payload)
 
     def get_skymap(self, nside=128):


### PR DESCRIPTION
This is a WIP change, based on some of the things we discussed at the last telecon.

All this does is make it more explicit how the different values for Mpointings are set within the database code.

Suggested changes/additions:

- [ ] Add something to the `Event` class to distinguish BBH/NS GW events.
- [ ] Alter strategy for different classed of GW events (e.g. different ranks).
- [ ] Move definitions into params, could be dicts like the daemon things in G-TeCS.