### PR TITLE
GOTO-tile update

### DIFF
--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -1,8 +1,6 @@
 #! /opt/local/bin/python3.6
 """Functions to add events into the GOTO Observation Database."""
 
-import numpy as np
-
 import obsdb as db
 
 
@@ -136,7 +134,7 @@ def get_grid_tiles(event, db_grid):
     # Mask the table based on tile probs
     # see https://github.com/GOTO-OBS/goto-alert/issues/26
     # mask based on if the mean tile pixel value is within the 90% contour
-    mask = [np.mean(event.skymap.contours[tile]) < 0.9 for tile in grid.pixels]
+    mask = grid.mean_contours < 0.9
     if sum(mask) < 1:
         # The source is probably so well localised that no tile has a mean contour of < 90%
         # This can happen for Swift GRBs.

--- a/gotoalert/database.py
+++ b/gotoalert/database.py
@@ -129,8 +129,18 @@ def get_grid_tiles(event, db_grid):
         event.get_skymap()
     grid.apply_skymap(event.skymap)
 
+    # Chose the contour level.
+    # NOTE: The code below is rather preliminary, based of what's best for 4- or 8-UT systems.
+    # It needs simulating to find the optimal value.
+    if grid.tile_area < 20:
+        # GOTO-4
+        contour_level = 0.9
+    else:
+        # GOTO-8
+        contour_level = 0.95
+
     # Get the table of tiles selected depending on the event
-    masked_table = grid.select_tiles(contour=0.9,
+    masked_table = grid.select_tiles(contour=contour_level,
                                      max_tiles=event.strategy['tile_limit'],
                                      min_tile_prob=event.strategy['prob_limit'],
                                      )

--- a/gotoalert/events.py
+++ b/gotoalert/events.py
@@ -261,8 +261,7 @@ class GWEvent(Event):
         # Get info from the skymap itself
         self.contour_areas = {}
         for contour in [0.5, 0.9]:
-            npix = len(self.skymap._pixels_within_contour(contour))
-            self.contour_areas[contour] = npix * self.skymap.pixel_area
+            self.contour_areas[contour] = self.skymap.get_contour_area(contour)
 
         return self.skymap
 
@@ -397,7 +396,6 @@ class GRBEvent(Event):
         # Get info from the skymap itself
         self.contour_areas = {}
         for contour in [0.5, 0.9]:
-            npix = len(self.skymap._pixels_within_contour(contour))
-            self.contour_areas[contour] = npix * self.skymap.pixel_area
+            self.contour_areas[contour] = self.skymap.get_contour_area(contour)
 
         return self.skymap


### PR DESCRIPTION
Modifies code for GOTO-OBS/goto-tile#74, which adds things like the contours and selecting functions to the appropriate classes.

Also add in a variable `contour_level` depending on the grid that's being used. Preliminary for now, but useful to start thinking about the GOTO-8 grid too. Doesn't really belong in this PR, but I can't be bothered to cherry-pick it out.